### PR TITLE
Add provider info API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>provider-api</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>provider-api</name>
+    <description>Provider API application</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/providerapi/ProviderApiApplication.java
+++ b/src/main/java/com/example/providerapi/ProviderApiApplication.java
@@ -1,0 +1,12 @@
+package com.example.providerapi;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ProviderApiApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ProviderApiApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/providerapi/controller/ProviderController.java
+++ b/src/main/java/com/example/providerapi/controller/ProviderController.java
@@ -1,0 +1,23 @@
+package com.example.providerapi.controller;
+
+import com.example.providerapi.model.ProviderInfo;
+import com.example.providerapi.service.ProviderInfoService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class ProviderController {
+
+    private final ProviderInfoService providerInfoService;
+
+    public ProviderController(ProviderInfoService providerInfoService) {
+        this.providerInfoService = providerInfoService;
+    }
+
+    @GetMapping("/getProviderInfo")
+    public List<ProviderInfo> getProviderInfo() {
+        return providerInfoService.getProviderInfo();
+    }
+}

--- a/src/main/java/com/example/providerapi/model/ProviderInfo.java
+++ b/src/main/java/com/example/providerapi/model/ProviderInfo.java
@@ -1,0 +1,25 @@
+package com.example.providerapi.model;
+
+public class ProviderInfo {
+    private final String providerId;
+    private final String name;
+    private final String address;
+
+    public ProviderInfo(String providerId, String name, String address) {
+        this.providerId = providerId;
+        this.name = name;
+        this.address = address;
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+}

--- a/src/main/java/com/example/providerapi/service/ProviderInfoService.java
+++ b/src/main/java/com/example/providerapi/service/ProviderInfoService.java
@@ -1,0 +1,20 @@
+package com.example.providerapi.service;
+
+import com.example.providerapi.model.ProviderInfo;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Service
+public class ProviderInfoService {
+
+    private final List<ProviderInfo> providers = IntStream.rangeClosed(1, 10)
+            .mapToObj(i -> new ProviderInfo("P" + i, "Provider " + i, "Address " + i))
+            .collect(Collectors.toList());
+
+    public List<ProviderInfo> getProviderInfo() {
+        return providers;
+    }
+}

--- a/src/test/java/com/example/providerapi/service/ProviderInfoServiceTest.java
+++ b/src/test/java/com/example/providerapi/service/ProviderInfoServiceTest.java
@@ -1,0 +1,23 @@
+package com.example.providerapi.service;
+
+import com.example.providerapi.model.ProviderInfo;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ProviderInfoServiceTest {
+
+    @Autowired
+    private ProviderInfoService providerInfoService;
+
+    @Test
+    void shouldReturnTenProviders() {
+        List<ProviderInfo> providers = providerInfoService.getProviderInfo();
+        assertEquals(10, providers.size());
+    }
+}


### PR DESCRIPTION
## Summary
- add Spring Boot project with endpoint `/getProviderInfo`
- implement provider info service returning 10 hard-coded providers
- include basic test for provider service

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689bd89ca634832da71cc89a7e5db9e4